### PR TITLE
Sanitize text input for dotool

### DIFF
--- a/internal/input/input_linux.go
+++ b/internal/input/input_linux.go
@@ -65,7 +65,10 @@ func (c *dotoolController) ExecuteCommands(ctx context.Context, commands []Comma
 }
 
 func (c *dotoolController) TypeText(ctx context.Context, text string) error {
-	return c.ExecuteCommands(ctx, []Command{{Action: "type", Args: text}})
+	// Replace newlines and surrounding whitespace with a single space
+	// to prevent dotool from interpreting newlines as command separators
+	sanitizedText := strings.Join(strings.Fields(text), " ")
+	return c.ExecuteCommands(ctx, []Command{{Action: "type", Args: sanitizedText}})
 }
 
 func (c *dotoolController) Close() error {


### PR DESCRIPTION
The dotool command interprets newlines as command separators, which can cause unexpected behaviour when typing text containing newlines. Replace newlines and surrounding whitespace with a single space to ensure the text is typed as a single command argument.

I was receiving warnings:

```
dotoolController.ExecuteCommands: completed successfully
dotool: WARNING: unknown command:  <more transcribed text>
dotool: WARNING: unknown command:  <even more transcribed text>
```

and only the first part of what was said was actually typed.