### PR TITLE
feat: Add barge-in to assistant mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VoxInput is meant to be used with [LocalAI](https://localai.io), but it will fun
 - **Noise Suppression**: Reduces background noise from the microphone input to improve transcription accuracy.
 - **Acoustic Echo Cancellation**: In assistant mode, cancels the assistant's own voice output from the microphone input to prevent feedback loops.
 - **Visual Notification**: In realtime mode, a GUI notification informs you when recording (VAD) has started or stopped.
-- **Assistant Mode**: Voice conversations with an LLM using the OpenAI Realtime API with bidirectional audio streaming, automatic speech detection, and voice responses.
+- **Assistant Mode**: Voice conversations with an LLM using the OpenAI Realtime API with bidirectional audio streaming, automatic speech detection, and voice responses. Supports barge-in: speak over the assistant to interrupt it mid-response.
 - **Desktop Control**: In assistant mode, the LLM can execute keyboard and mouse commands through function calls to control your desktop environment.
 - **Screenshot Capture**: In assistant mode, the LLM can request a screenshot of your desktop to provide visual context for its responses.
 - **Terminal UI**: Interactive TUI mode (`voxinput tui`) with chat and log tabs, recording controls, and the ability to attach to a running listen process.
@@ -282,8 +282,9 @@ When you start VoxInput in assistant mode:
 1. **Start recording**: Use `./voxinput record` to begin a conversation
 2. **Speak naturally**: The assistant uses server-side Voice Activity Detection (VAD) to detect when you're speaking
 3. **Get responses**: The assistant responds with voice audio streamed back to you
-4. **Desktop actions**: When configured with the `dotool` function, the assistant can execute keyboard and mouse commands
-5. **Continue or stop**: Keep talking for a back-and-forth conversation, or use `./voxinput stop` to end
+4. **Interrupt anytime**: Start talking while the assistant is speaking and it stops immediately (barge-in), discarding the rest of its current response and listening to you instead
+5. **Desktop actions**: When configured with the `dotool` function, the assistant can execute keyboard and mouse commands
+6. **Continue or stop**: Keep talking for a back-and-forth conversation, or use `./voxinput stop` to end
 
 The assistant receives your speech in real-time, transcribes it automatically, generates a response using the configured LLM, and speaks the response back to you - all while optionally executing desktop commands when appropriate.
 

--- a/assistant.go
+++ b/assistant.go
@@ -141,6 +141,12 @@ func (l *Listener) runAudioAssistant() {
 }
 
 func (l *Listener) ReceiveAssistantMessages() {
+	// Track the in-progress response so a barge-in (user speaking over the
+	// assistant) only fires while there is something to interrupt. These are
+	// touched solely from this goroutine, so no synchronisation is needed.
+	var responseActive bool
+	var activeResponseID string
+
 	for {
 		msg, err := l.conn.ReadMessage(l.ctx)
 		if err != nil {
@@ -158,17 +164,36 @@ func (l *Listener) ReceiveAssistantMessages() {
 		case openairt.ServerEventTypeInputAudioBufferSpeechStarted:
 			log.Println("Listener.ReceiveAssistantMessages: speech detected")
 			l.config.UI.Send(&gui.ShowSpeechDetectedMsg{})
+			// Barge-in: the user is talking over the assistant. Drop the
+			// queued TTS so playback stops at once and tell the server to
+			// abandon the response it is still streaming.
+			if responseActive {
+				l.bargeIn(activeResponseID)
+				responseActive = false
+				activeResponseID = ""
+			}
 		case openairt.ServerEventTypeInputAudioBufferSpeechStopped:
 			log.Println("Listener.ReceiveAssistantMessages: speech stopped, processing")
 			l.config.UI.Send(&gui.ShowSpeechSubmittedMsg{})
 		case openairt.ServerEventTypeResponseCreated:
 			log.Println("Listener.ReceiveAssistantMessages: generating response")
+			responseActive = true
+			activeResponseID = msg.(openairt.ResponseCreatedEvent).Response.ID
 			l.config.UI.Send(&gui.ShowGeneratingResponseMsg{})
+		case openairt.ServerEventTypeResponseDone:
+			log.Println("Listener.ReceiveAssistantMessages: response done")
+			responseActive = false
+			activeResponseID = ""
 		case openairt.ServerEventTypeConversationItemInputAudioTranscriptionCompleted:
 			transcript := msg.(openairt.ConversationItemInputAudioTranscriptionCompletedEvent).Transcript
 			log.Printf("Listener.ReceiveAssistantMessages: user said: %s", transcript)
 			l.config.UI.Send(&gui.ShowTranscriptMsg{Text: transcript, IsUser: true})
 		case openairt.ServerEventTypeResponseOutputAudioDelta:
+			// Drop deltas once the response has been barged in on; they would
+			// otherwise refill the playback buffer we just flushed.
+			if !responseActive {
+				continue
+			}
 			delta := msg.(openairt.ResponseOutputAudioDeltaEvent)
 			b, err := base64.StdEncoding.DecodeString(delta.Delta)
 			if err != nil {
@@ -228,6 +253,20 @@ func (l *Listener) ReceiveAssistantMessages() {
 			continue
 		}
 
+	}
+}
+
+// bargeIn aborts the assistant mid-response when the user starts speaking. It
+// flushes the locally queued TTS audio so the speaker goes quiet immediately
+// and asks the server to cancel the response so no further audio is generated.
+func (l *Listener) bargeIn(responseID string) {
+	log.Println("Listener.bargeIn: user interrupted, cancelling response")
+	l.playReader.Flush()
+
+	if err := l.conn.SendMessage(l.ctx, openairt.ResponseCancelEvent{
+		ResponseID: responseID,
+	}); err != nil {
+		log.Println("Listener.bargeIn: error cancelling response: ", err)
 	}
 }
 

--- a/assistant.go
+++ b/assistant.go
@@ -164,14 +164,13 @@ func (l *Listener) ReceiveAssistantMessages() {
 		case openairt.ServerEventTypeInputAudioBufferSpeechStarted:
 			log.Println("Listener.ReceiveAssistantMessages: speech detected")
 			l.config.UI.Send(&gui.ShowSpeechDetectedMsg{})
-			// Barge-in: the user is talking over the assistant. Drop the
-			// queued TTS so playback stops at once and tell the server to
-			// abandon the response it is still streaming.
-			if responseActive {
-				l.bargeIn(activeResponseID)
-				responseActive = false
-				activeResponseID = ""
-			}
+			// Barge-in: the user is talking over the assistant. The local
+			// playback buffer can hold seconds of TTS that arrived in a burst,
+			// so always flush it here regardless of server response state. Only
+			// send response.cancel when the server is still streaming.
+			l.bargeIn(responseActive, activeResponseID)
+			responseActive = false
+			activeResponseID = ""
 		case openairt.ServerEventTypeInputAudioBufferSpeechStopped:
 			log.Println("Listener.ReceiveAssistantMessages: speech stopped, processing")
 			l.config.UI.Send(&gui.ShowSpeechSubmittedMsg{})
@@ -256,12 +255,21 @@ func (l *Listener) ReceiveAssistantMessages() {
 	}
 }
 
-// bargeIn aborts the assistant mid-response when the user starts speaking. It
-// flushes the locally queued TTS audio so the speaker goes quiet immediately
-// and asks the server to cancel the response so no further audio is generated.
-func (l *Listener) bargeIn(responseID string) {
-	log.Println("Listener.bargeIn: user interrupted, cancelling response")
-	l.playReader.Flush()
+// bargeIn aborts the assistant when the user starts speaking. It always
+// flushes the locally queued TTS so the speaker goes quiet immediately; the
+// buffer routinely outlives the server response because audio arrives in a
+// burst. When the server is still streaming (responseActive), it also sends
+// response.cancel so no further audio is generated.
+func (l *Listener) bargeIn(responseActive bool, responseID string) {
+	dropped := l.playReader.Flush()
+	if dropped == 0 && !responseActive {
+		return
+	}
+	log.Printf("Listener.bargeIn: user interrupted, dropped %d bytes of queued audio", dropped)
+
+	if !responseActive {
+		return
+	}
 
 	if err := l.conn.SendMessage(l.ctx, openairt.ResponseCancelEvent{
 		ResponseID: responseID,

--- a/internal/audio/chunk.go
+++ b/internal/audio/chunk.go
@@ -99,19 +99,25 @@ func (r *ChunkReader) drainAvailable() {
 }
 
 // Flush discards all buffered and queued audio, returning the reader to the
-// pre-roll buffering state. Used for barge-in: when the user starts speaking
-// while the assistant is talking, the already-queued TTS audio must be dropped
-// so playback stops immediately rather than draining to the end of the
-// response. Safe to call concurrently with Read.
-func (r *ChunkReader) Flush() {
+// pre-roll buffering state, and reports how many bytes were dropped. Used for
+// barge-in: when the user starts speaking while the assistant is talking, the
+// already-queued TTS audio must be dropped so playback stops immediately
+// rather than draining to the end of the response. The server streams a whole
+// response's audio in a burst, so this buffer can hold seconds of speech long
+// after the response is "done" server-side. Safe to call concurrently with
+// Read.
+func (r *ChunkReader) Flush() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.drainAvailable()
+	// pendingBytes already accounts for the unread tail of r.current.
+	dropped := r.pendingBytes
 	r.current = nil
 	r.pending = nil
 	r.pendingBytes = 0
 	r.buffering = true
+	return dropped
 }
 
 func (r *ChunkReader) Read(p []byte) (int, error) {

--- a/internal/audio/chunk.go
+++ b/internal/audio/chunk.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"bytes"
 	"context"
+	"sync"
 	"time"
 )
 
@@ -59,6 +60,7 @@ func (w *ChunkWriter) Write(p []byte) (n int, err error) {
 type ChunkReader struct {
 	ctx          context.Context
 	chunks       <-chan *bytes.Buffer
+	mu           sync.Mutex
 	current      *bytes.Buffer
 	pending      []*bytes.Buffer
 	pendingBytes int
@@ -96,10 +98,29 @@ func (r *ChunkReader) drainAvailable() {
 	}
 }
 
+// Flush discards all buffered and queued audio, returning the reader to the
+// pre-roll buffering state. Used for barge-in: when the user starts speaking
+// while the assistant is talking, the already-queued TTS audio must be dropped
+// so playback stops immediately rather than draining to the end of the
+// response. Safe to call concurrently with Read.
+func (r *ChunkReader) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.drainAvailable()
+	r.current = nil
+	r.pending = nil
+	r.pendingBytes = 0
+	r.buffering = true
+}
+
 func (r *ChunkReader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	r.drainAvailable()
 


### PR DESCRIPTION
Let the user interrupt the assistant mid-response by speaking over it.
On a server VAD speech_started event during an active response, flush the
locally queued TTS audio so the speaker goes quiet immediately and send a
response.cancel so the server stops generating further audio. Straggler
audio deltas arriving after the barge-in are dropped to avoid refilling the
buffer we just flushed.

ChunkReader gains a Flush method that discards queued and buffered audio and
re-arms the preroll buffering state. A mutex now guards its buffer fields
since Flush runs on the message goroutine while Read runs on the audio
callback goroutine.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
