### PR TITLE
feat: Add translation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VoxInput is meant to be used with [LocalAI](https://localai.io), but it will fun
 - **Noise Suppression**: Reduces background noise from the microphone input to improve transcription accuracy.
 - **Acoustic Echo Cancellation**: In assistant mode, cancels the assistant's own voice output from the microphone input to prevent feedback loops.
 - **Visual Notification**: In realtime mode, a GUI notification informs you when recording (VAD) has started or stopped.
+- **Translation Mode**: Transcribes speech in realtime, then streams each transcript chunk to the chat completions API for translation (English by default) before typing or saving it.
 - **Assistant Mode**: Voice conversations with an LLM using the OpenAI Realtime API with bidirectional audio streaming, automatic speech detection, and voice responses. Supports barge-in: speak over the assistant to interrupt it mid-response.
 - **Desktop Control**: In assistant mode, the LLM can execute keyboard and mouse commands through function calls to control your desktop environment.
 - **Screenshot Capture**: In assistant mode, the LLM can request a screenshot of your desktop to provide visual context for its responses.
@@ -92,7 +93,9 @@ Unless you don't mind running VoxInput as root, then you also need to ensure the
 - `VOXINPUT_SHOW_STATUS`: Show GUI notifications (`yes`/`no`, default: `yes`).
 - `VOXINPUT_CAPTURE_DEVICE`: Specific audio capture device name (run `voxinput devices` to list).
 - `VOXINPUT_OUTPUT_FILE`: Path to save the transcribed text to a file instead of typing it with dotool.
-- `VOXINPUT_MODE`: Realtime mode (transcription|assistant, default: transcription).
+- `VOXINPUT_MODE`: Realtime mode (transcription|translation|assistant, default: transcription).
+- `VOXINPUT_TRANSLATION_MODEL`: Chat completions model used to translate transcript chunks in translation mode (default: none).
+- `VOXINPUT_TRANSLATION_INSTRUCTIONS`: System prompt for the translation model (default: `translate to english literally with minimal explanations`).
 - `VOXINPUT_INPUT_SAMPLE_RATE`: Sample rate for audio input in Hz (default: 24000). Used for capturing audio and for realtime API input.
 - `VOXINPUT_OUTPUT_SAMPLE_RATE`: Sample rate for audio output in Hz (default: 24000). Used for realtime API output and audio playback.
 - `VOXINPUT_AEC_FILTER_MS`: AEC filter length in milliseconds (default: 200).
@@ -118,8 +121,10 @@ Unless you don't mind running VoxInput as root, then you also need to ensure the
   - `--no-show-status`: Don't show when recording has started or stopped.
   - `--output-file <path>`: Save transcript to file instead of typing.
   - `--prompt <text>`: Text used to condition model output. Could be previously transcribed text or uncommon words you expect to use
-  - `--mode <transcription|assistant>`: Realtime mode (default: transcription)
+  - `--mode <transcription|translation|assistant>`: Realtime mode (default: transcription)
   - `--instructions <text>`: System prompt for the assistant model
+  - `--translation-model <model>`: (translation mode only) Chat model used to translate transcript chunks
+  - `--translation-instructions <text>`: (translation mode only) System prompt for the translation model
   - `--no-dotool`: (assistant mode only) Disable the dotool function call
   - `--screenshot-command <cmd>`: (assistant mode only) Command to capture a screenshot (e.g. `grim /tmp/screenshot.png`)
   - `--screenshot-file <path>`: (assistant mode only) Path where the screenshot command saves its output

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -26,6 +26,9 @@ type ShowStoppingMsg struct{}
 type ShowTranscriptMsg struct {
 	Text   string
 	IsUser bool
+	// Label overrides the speaker prefix in the chat view (e.g. "Original",
+	// "Translation"). Empty falls back to "You"/"Assistant" by IsUser.
+	Label string
 }
 
 func (m *ShowListeningMsg) IsMsg() bool          { return true }

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -26,6 +26,7 @@ type Event struct {
 	Text      string    `json:"text"`
 	Detail    string    `json:"detail,omitempty"`
 	IsUser    bool      `json:"is_user,omitempty"`
+	Label     string    `json:"label,omitempty"`
 	Recording bool      `json:"recording,omitempty"`
 }
 
@@ -115,7 +116,7 @@ func EventFromGUIMsg(msg gui.Msg) Event {
 	case *gui.ShowStoppingMsg:
 		return Event{Kind: EventStatus, Text: "Stopping listening"}
 	case *gui.ShowTranscriptMsg:
-		return Event{Kind: EventTranscript, Text: m.Text, IsUser: m.IsUser}
+		return Event{Kind: EventTranscript, Text: m.Text, IsUser: m.IsUser, Label: m.Label}
 	case *gui.HideMsg:
 		return Event{Kind: EventStatus, Text: ""}
 	default:

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -12,15 +12,18 @@ func renderChatEvent(e ipc.Event) string {
 
 	switch e.Kind {
 	case ipc.EventTranscript:
+		label := "Assistant:"
+		style := assistantStyle
 		if e.IsUser {
-			return fmt.Sprintf("%s %s %s",
-				logTimestampStyle.Render(ts),
-				userStyle.Render("You:"),
-				e.Text)
+			label = "You:"
+			style = userStyle
+		}
+		if e.Label != "" {
+			label = e.Label + ":"
 		}
 		return fmt.Sprintf("%s %s %s",
 			logTimestampStyle.Render(ts),
-			assistantStyle.Render("Assistant:"),
+			style.Render(label),
 			e.Text)
 
 	case ipc.EventStatus:

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -18,6 +18,21 @@ func TestRenderTranscriptEvent(t *testing.T) {
 	}
 }
 
+func TestRenderTranscriptEventLabel(t *testing.T) {
+	orig := renderChatEvent(ipc.Event{Kind: ipc.EventTranscript, Ts: 1000, Text: "hola", IsUser: true, Label: "Original"})
+	if !strings.Contains(orig, "Original:") || !strings.Contains(orig, "hola") {
+		t.Errorf("expected 'Original:' and 'hola' in %q", orig)
+	}
+	if strings.Contains(orig, "You:") {
+		t.Errorf("did not expect 'You:' when Label is set, got %q", orig)
+	}
+
+	trans := renderChatEvent(ipc.Event{Kind: ipc.EventTranscript, Ts: 1000, Text: "hello", IsUser: false, Label: "Translation"})
+	if !strings.Contains(trans, "Translation:") || !strings.Contains(trans, "hello") {
+		t.Errorf("expected 'Translation:' and 'hello' in %q", trans)
+	}
+}
+
 func TestRenderStatusEvent(t *testing.T) {
 	e := ipc.Event{Kind: ipc.EventStatus, Ts: 1000, Text: "Listening..."}
 	rendered := renderChatEvent(e)

--- a/listen.go
+++ b/listen.go
@@ -20,6 +20,7 @@ import (
 
 	openairt "github.com/WqyJh/go-openai-realtime/v2"
 	"github.com/gen2brain/malgo"
+	"github.com/sashabaranov/go-openai"
 
 	"github.com/richiejp/VoxInput/internal/audio"
 	"github.com/richiejp/VoxInput/internal/gui"
@@ -114,38 +115,40 @@ const (
 )
 
 type ListenConfig struct {
-	PIDPath              string
-	APIKey               string
-	HTTPAPIBase          string
-	WSAPIBase            string
-	Lang                 string
-	Model                string
-	Timeout              time.Duration
-	UI                   gui.StatusSink
-	CaptureDevice        string
-	OutputFile           string
-	Prompt               string
-	Mode                 string
-	AssistantModel       string
-	AssistantVoice       string
-	Instructions         string
-	EnableDotool         bool
-	InputController      input.Controller
-	ScreenshotCommand    string
-	ScreenshotFile       string
-	InputSampleRate      int
-	OutputSampleRate     int
-	EnableAEC            bool
-	LocalVQEModelPath    string
-	LocalVQEModelVersion localvqe.ModelVariant
-	LocalVQELibPath      string
-	AECRefSource         AECRefSource
-	AECMonitorDevice     string
-	AECNoiseGate         bool
-	AECNoiseGateDBFS     float32
-	RefRing              *audio.Int16Ring
-	DumpAudioDir         string
-	IPCServer            *ipc.Server
+	PIDPath                 string
+	APIKey                  string
+	HTTPAPIBase             string
+	WSAPIBase               string
+	Lang                    string
+	Model                   string
+	Timeout                 time.Duration
+	UI                      gui.StatusSink
+	CaptureDevice           string
+	OutputFile              string
+	Prompt                  string
+	Mode                    string
+	TranslationModel        string
+	TranslationInstructions string
+	AssistantModel          string
+	AssistantVoice          string
+	Instructions            string
+	EnableDotool            bool
+	InputController         input.Controller
+	ScreenshotCommand       string
+	ScreenshotFile          string
+	InputSampleRate         int
+	OutputSampleRate        int
+	EnableAEC               bool
+	LocalVQEModelPath       string
+	LocalVQEModelVersion    localvqe.ModelVariant
+	LocalVQELibPath         string
+	AECRefSource            AECRefSource
+	AECMonitorDevice        string
+	AECNoiseGate            bool
+	AECNoiseGateDBFS        float32
+	RefRing                 *audio.Int16Ring
+	DumpAudioDir            string
+	IPCServer               *ipc.Server
 }
 
 type Listener struct {
@@ -166,6 +169,7 @@ type Listener struct {
 	aecMicRing       *audio.Int16Ring
 	aecRefRing       *audio.Int16Ring
 	aecDumpProcessed io.Writer
+	chatCli          *openai.Client
 }
 
 func NewListener(config ListenConfig, streamConfig audio.StreamConfig, rtCli *openairt.Client, statePath string, processor audio.AudioProcessor) *Listener {
@@ -269,6 +273,15 @@ func NewListener(config ListenConfig, streamConfig audio.StreamConfig, rtCli *op
 		}
 		l.duplexOpts.AECMicRing = l.aecMicRing
 		l.duplexOpts.AECRefRing = l.aecRefRing
+	}
+
+	// Translation mode post-processes each transcript chunk through the chat
+	// completions API, so it needs an HTTP client alongside the realtime one.
+	if config.Mode == "translation" {
+		chatConf := openai.DefaultConfig(config.APIKey)
+		chatConf.BaseURL = config.HTTPAPIBase
+		chatConf.HTTPClient = &http.Client{Timeout: config.Timeout}
+		l.chatCli = openai.NewClientWithConfig(chatConf)
 	}
 
 	return l

--- a/main.go
+++ b/main.go
@@ -47,8 +47,10 @@ func main() {
            --no-show-status don't show when recording has started or stopped
            --output-file <path> Write transcribed text to file instead of keyboard
            --prompt <text> Text used to condition model output. Could be previously transcribed text or uncommon words you expect to use
-           --mode <transcription|assistant> (realtime only, default: transcription)
+           --mode <transcription|translation|assistant> (realtime only, default: transcription)
            --instructions <text> System prompt for the assistant model
+           --translation-model <model> (translation mode only) Chat model used to translate transcript chunks
+           --translation-instructions <text> (translation mode only) System prompt for the translation model
            --no-dotool (assistant mode only) Disable the dotool function call
            --no-aec (assistant mode only) Disable acoustic echo cancellation
            --screenshot-command <cmd> (assistant mode only) Command to capture a screenshot (e.g. "grim /tmp/screenshot.png")
@@ -87,7 +89,9 @@ Environment variables:
   VOXINPUT_CAPTURE_DEVICE - Name of the capture device (default: system default; use 'devices' to list)
   VOXINPUT_OUTPUT_FILE - File to write transcribed text to (instead of keyboard)
   VOXINPUT_PROMPT - Text used to condition the transcription model output. Could be previously transcribed text or uncommon words you expect to use (default: none)
-  VOXINPUT_MODE - Realtime mode (transcription|assistant, default: transcription)
+  VOXINPUT_MODE - Realtime mode (transcription|translation|assistant, default: transcription)
+  VOXINPUT_TRANSLATION_MODEL - Chat completions model used to translate transcript chunks in translation mode (default: none)
+  VOXINPUT_TRANSLATION_INSTRUCTIONS - System prompt for the translation model (default: "translate to english literally with minimal explanations")
   VOXINPUT_ENABLE_AEC - Enable acoustic echo cancellation in assistant mode (yes/no, default: yes)
   VOXINPUT_LOCALVQE_MODEL - Path to a LocalVQE GGUF model file, overriding the bundled models (default: the bundled model selected by VOXINPUT_LOCALVQE_MODEL_VERSION)
   VOXINPUT_LOCALVQE_MODEL_VERSION - Which bundled LocalVQE model to use: v1.2 (default) or v1.3; also accepts the full version-size form (v1.2-1.3M, v1.3-4.8M). Both are bundled by the CMake build; with a plain 'go build' the chosen model is downloaded into the user cache on first use. Ignored when VOXINPUT_LOCALVQE_MODEL is set.
@@ -157,6 +161,8 @@ Environment variables:
 		aecNoiseGateDBFSStr := getPrefixedEnv([]string{"VOXINPUT"}, "AEC_NOISE_GATE_DBFS", "-45.0")
 
 		mode := getPrefixedEnv([]string{"VOXINPUT"}, "MODE", "transcription")
+		translationModel := getPrefixedEnv([]string{"VOXINPUT"}, "TRANSLATION_MODEL", "")
+		translationInstructions := getPrefixedEnv([]string{"VOXINPUT"}, "TRANSLATION_INSTRUCTIONS", "translate to english literally with minimal explanations")
 		socketPath := getPrefixedEnv([]string{"VOXINPUT"}, "SOCKET", "")
 		screenshotCommand := getPrefixedEnv([]string{"VOXINPUT"}, "ASSISTANT_SCREENSHOT_COMMAND", "")
 		screenshotFile := getPrefixedEnv([]string{"VOXINPUT"}, "ASSISTANT_SCREENSHOT_FILE", "")
@@ -247,6 +253,22 @@ Environment variables:
 		}
 		if instructionsArg != "" {
 			instructions = instructionsArg
+		}
+
+		for i := 2; i < len(os.Args); i++ {
+			arg := os.Args[i]
+			if arg == "--translation-model" && i+1 < len(os.Args) {
+				translationModel = os.Args[i+1]
+				break
+			}
+		}
+
+		for i := 2; i < len(os.Args); i++ {
+			arg := os.Args[i]
+			if arg == "--translation-instructions" && i+1 < len(os.Args) {
+				translationInstructions = os.Args[i+1]
+				break
+			}
 		}
 
 		for i := 2; i < len(os.Args); i++ {
@@ -362,37 +384,39 @@ Environment variables:
 
 			go func() {
 				listen(ListenConfig{
-					PIDPath:              pidPath,
-					APIKey:               apiKey,
-					HTTPAPIBase:          httpApiBase,
-					WSAPIBase:            wsApiBase,
-					Lang:                 lang,
-					Model:                model,
-					Timeout:              timeout,
-					UI:                   sink,
-					CaptureDevice:        captureDeviceName,
-					OutputFile:           outputFile,
-					Prompt:               prompt,
-					Mode:                 mode,
-					AssistantModel:       assistantModel,
-					AssistantVoice:       assistantVoice,
-					Instructions:         instructions,
-					EnableDotool:         enableDotool,
-					InputController:      inputCtrl,
-					ScreenshotCommand:    screenshotCommand,
-					ScreenshotFile:       screenshotFile,
-					InputSampleRate:      inputSampleRate,
-					OutputSampleRate:     outputSampleRate,
-					EnableAEC:            enableAEC,
-					LocalVQEModelPath:    localvqeModelPath,
-					LocalVQEModelVersion: localvqe.ModelVariant(localvqeModelVersion),
-					LocalVQELibPath:      localvqeLibPath,
-					AECRefSource:         aecRefSource,
-					AECMonitorDevice:     aecMonitorDevice,
-					AECNoiseGate:         aecNoiseGate,
-					AECNoiseGateDBFS:     aecNoiseGateDBFS,
-					DumpAudioDir:         dumpAudioDir,
-					IPCServer:            ipcServer,
+					PIDPath:                 pidPath,
+					APIKey:                  apiKey,
+					HTTPAPIBase:             httpApiBase,
+					WSAPIBase:               wsApiBase,
+					Lang:                    lang,
+					Model:                   model,
+					Timeout:                 timeout,
+					UI:                      sink,
+					CaptureDevice:           captureDeviceName,
+					OutputFile:              outputFile,
+					Prompt:                  prompt,
+					Mode:                    mode,
+					TranslationModel:        translationModel,
+					TranslationInstructions: translationInstructions,
+					AssistantModel:          assistantModel,
+					AssistantVoice:          assistantVoice,
+					Instructions:            instructions,
+					EnableDotool:            enableDotool,
+					InputController:         inputCtrl,
+					ScreenshotCommand:       screenshotCommand,
+					ScreenshotFile:          screenshotFile,
+					InputSampleRate:         inputSampleRate,
+					OutputSampleRate:        outputSampleRate,
+					EnableAEC:               enableAEC,
+					LocalVQEModelPath:       localvqeModelPath,
+					LocalVQEModelVersion:    localvqe.ModelVariant(localvqeModelVersion),
+					LocalVQELibPath:         localvqeLibPath,
+					AECRefSource:            aecRefSource,
+					AECMonitorDevice:        aecMonitorDevice,
+					AECNoiseGate:            aecNoiseGate,
+					AECNoiseGateDBFS:        aecNoiseGateDBFS,
+					DumpAudioDir:            dumpAudioDir,
+					IPCServer:               ipcServer,
 				})
 				cancel()
 			}()

--- a/transcription.go
+++ b/transcription.go
@@ -6,11 +6,40 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	openairt "github.com/WqyJh/go-openai-realtime/v2"
 	"github.com/richiejp/VoxInput/internal/audio"
 	"github.com/richiejp/VoxInput/internal/gui"
+	"github.com/sashabaranov/go-openai"
 )
+
+// translate sends a transcript chunk to the chat completions API and returns
+// the model's translation. The system prompt is configurable; it defaults to a
+// literal English translation with minimal explanation.
+func (l *Listener) translate(ctx context.Context, text string) (string, error) {
+	resp, err := l.chatCli.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: l.config.TranslationModel,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: l.config.TranslationInstructions,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: text,
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("translation chat completion: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("translation returned no choices")
+	}
+
+	return strings.TrimSpace(resp.Choices[0].Message.Content), nil
+}
 
 func (l *Listener) startTranscriptionSession(ctx context.Context) error {
 	var transcription *openairt.AudioTranscription
@@ -86,16 +115,44 @@ func (l *Listener) ReceiveTranscriptionMessages() {
 		if text == "" {
 			continue
 		}
+		// In translation mode the raw transcript is shown as the "Original"
+		// line and the translation as the "Translation" line; otherwise the
+		// transcript is the user's own speech ("You").
+		translating := l.config.Mode == "translation"
+		userMsg := &gui.ShowTranscriptMsg{Text: text, IsUser: true}
+		if translating {
+			userMsg.Label = "Original"
+		}
 		l.config.UI.Send(&gui.HideMsg{})
-		l.config.UI.Send(&gui.ShowTranscriptMsg{Text: text, IsUser: true})
+		l.config.UI.Send(userMsg)
 		log.Println("Listener.ReceiveTranscriptionMessages: received transcribed text: ", text)
+
+		// In translation mode the raw transcript is handed to the chat
+		// completions API and the translation replaces it for output.
+		out := text
+		if translating {
+			l.config.UI.Send(&gui.ShowGeneratingResponseMsg{})
+			translated, err := l.translate(l.ctx, text)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				log.Println("Listener.ReceiveTranscriptionMessages: translation failed: ", err)
+				continue
+			}
+			log.Printf("Listener.ReceiveTranscriptionMessages: translated text: %q", translated)
+			l.config.UI.Send(&gui.HideMsg{})
+			l.config.UI.Send(&gui.ShowTranscriptMsg{Text: translated, IsUser: false, Label: "Translation"})
+			out = translated
+		}
+
 		if l.config.OutputFile != "" {
 			f, err := os.OpenFile(l.config.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Printf("Failed to open output file %s: %v\n", l.config.OutputFile, err)
 				continue
 			}
-			if _, err := fmt.Fprintln(f, text); err != nil {
+			if _, err := fmt.Fprintln(f, out); err != nil {
 				log.Printf("Failed to write to output file: %v\n", err)
 			}
 			if err := f.Close(); err != nil {
@@ -103,12 +160,12 @@ func (l *Listener) ReceiveTranscriptionMessages() {
 			}
 			continue
 		}
-		log.Printf("Listener.ReceiveTranscriptionMessages: typing text: %q", text)
+		log.Printf("Listener.ReceiveTranscriptionMessages: typing text: %q", out)
 		if l.config.InputController == nil {
 			log.Println("Listener.ReceiveTranscriptionMessages: no input controller available, cannot type text")
 			continue
 		}
-		if err := l.config.InputController.TypeText(l.ctx, text); err != nil {
+		if err := l.config.InputController.TypeText(l.ctx, out); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return
 			}


### PR DESCRIPTION
Add a "translation" realtime mode that reuses the transcription session
and audio path, then post-processes each transcript chunk through the
chat completions API before typing or saving it. Configured via
VOXINPUT_TRANSLATION_MODEL / VOXINPUT_TRANSLATION_INSTRUCTIONS (default
system prompt "translate to english literally with minimal explanations")
and the matching --translation-model / --translation-instructions flags.

The TUI distinguishes the two lines per utterance via a new optional
Label on ShowTranscriptMsg (plumbed through ipc.Event), rendered as
"Original:" / "Translation:" and falling back to "You:" / "Assistant:"
when unset so other modes are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
